### PR TITLE
chore: Migrate from with_items to loop

### DIFF
--- a/tasks/laurel_config.yml
+++ b/tasks/laurel_config.yml
@@ -128,7 +128,9 @@
       ansible.builtin.copy:
         src: "{{ item.path }}"
         dest: "{{ laurel_build_dir }}/selinux/{{ item.path | basename }}"
-      with_items: "{{ found_files.files }}"
+      loop: "{{ found_files.files }}"
+      loop_control:
+        label: "{{ item.path | basename }}"
       when: test is not defined
 
     - name: Compile SELinux policy


### PR DESCRIPTION
Given that `with_items` is deprecated in Ansible, this migrated the role to use `loop` instead.

It also sets the loop label to make the playbook output easier to read.