### PR TITLE
add: meta/main.yml

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,19 @@
+galaxy_info:
+  namespace: certeu
+  role_name: ansible-auditd-laurel
+  author: certeu
+  description: Install LAUREL (Linux Audit and Enrichment Layer)
+  licence: GPL-3.0
+
+  platforms:
+    - name: Debian
+      versions:
+        - 10
+        - 11
+        - 12
+    - name: RedHat
+      versions:
+        - 8
+        - 9
+
+dependencies: []


### PR DESCRIPTION
# Add meta/main.yml

## Summary
This PR adds meta/main.yml, so the role is easily re-usable from any Ansible project by referencing it in its collections/requirements.yml, as in:

    roles:
       - name: laurel
         src: git+https://github.com/certeu/ansible-auditd-laurel.git
         version: main